### PR TITLE
Add filtering options to GetCoaches endpoint and implement GetCoachesBySportId query; enhance coach availability retrieval with date validation

### DIFF
--- a/SCRMS-SEP.slnLaunch.user
+++ b/SCRMS-SEP.slnLaunch.user
@@ -32,5 +32,18 @@
         "Action": "Start"
       }
     ]
+  },
+  {
+    "Name": "court coach",
+    "Projects": [
+      {
+        "Path": "src\\Services\\Coach\\Coach.API\\Coach.API.csproj",
+        "Action": "Start"
+      },
+      {
+        "Path": "src\\Services\\CourtBooking\\CourtBooking.API\\CourtBooking.API.csproj",
+        "Action": "Start"
+      }
+    ]
   }
 ]

--- a/src/Services/Coach/Coach.API/Data/Repositories/CoachSportRepository.cs
+++ b/src/Services/Coach/Coach.API/Data/Repositories/CoachSportRepository.cs
@@ -44,6 +44,12 @@ namespace Coach.API.Data.Repositories
             return await _context.CoachSports.Where(cs => cs.CoachId == coachId).ToListAsync(cancellationToken);
         }
 
+        public async Task<IEnumerable<CoachSport>> GetCoachesBySportIdAsync(Guid sportId, CancellationToken cancellationToken)
+        {
+            return await _context.CoachSports
+                .Where(cs => cs.SportId == sportId)
+                .ToListAsync(cancellationToken);
+        }
         public async Task DeleteCoachSportAsync(CoachSport coachSport, CancellationToken cancellationToken)
         {
             var existingCoachSport = await _context.CoachSports

--- a/src/Services/Coach/Coach.API/Data/Repositories/ICoachSportRepository.cs
+++ b/src/Services/Coach/Coach.API/Data/Repositories/ICoachSportRepository.cs
@@ -7,6 +7,7 @@ namespace Coach.API.Data.Repositories
         Task AddCoachSportAsync(CoachSport coachSport, CancellationToken cancellationToken);
 
         Task<List<CoachSport>> GetCoachSportsByCoachIdAsync(Guid coachId, CancellationToken cancellationToken);
+        Task<IEnumerable<CoachSport>> GetCoachesBySportIdAsync(Guid sportId, CancellationToken cancellationToken);
 
         Task DeleteCoachSportAsync(CoachSport coachSport, CancellationToken cancellationToken);
     }

--- a/src/Services/Coach/Coach.API/Features/Coaches/GetCoaches/GetCoachesEndpoint.cs
+++ b/src/Services/Coach/Coach.API/Features/Coaches/GetCoaches/GetCoachesEndpoint.cs
@@ -6,13 +6,21 @@ namespace Coach.API.Features.Coaches.GetCoaches
     {
         public void AddRoutes(IEndpointRouteBuilder app)
         {
-            app.MapGet("/coaches", async ([FromServices] ISender sender) =>
+            app.MapGet("/coaches", async (
+                [FromQuery] string? name,
+                [FromQuery] Guid? sportId,
+                [FromQuery] decimal? minPrice,
+                [FromQuery] decimal? maxPrice,
+                [FromServices] ISender sender) =>
             {
-                var result = await sender.Send(new GetCoachesQuery());
+                var query = new GetCoachesQuery(name, sportId, minPrice, maxPrice);
+                var result = await sender.Send(query);
                 return Results.Ok(result);
             })
             .WithName("GetCoaches")
-            .Produces<IEnumerable<CoachResponse>>().WithTags("Coach");
+            .Produces<IEnumerable<CoachResponse>>()
+            .WithTags("Coach")
+            .WithDescription("Get all coaches with optional filtering by name, sport, and price range");
         }
     }
 }

--- a/src/Services/Coach/Coach.API/Features/Schedules/ViewAvailableSchedule/ViewCoachAvailabilityEndpoint.cs
+++ b/src/Services/Coach/Coach.API/Features/Schedules/ViewAvailableSchedule/ViewCoachAvailabilityEndpoint.cs
@@ -47,6 +47,39 @@ namespace Coach.API.Features.Schedules.GetCoachSchedules
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .WithSummary("Get Coach Schedules")
             .WithDescription("Lấy danh sách lịch làm việc của coach theo ngày với phân trang và lọc.").WithTags("Schedule");
+
+            app.MapGet("/api/public/coach-schedules/{coachId:guid}", async (
+               [FromServices] ISender sender,
+               Guid coachId,
+               string start_date,
+               string end_date,
+               int page = 1,
+               int recordPerPage = 10) =>
+           {
+               // Validate and parse start_date
+               if (!DateOnly.TryParse(start_date, out var startDate))
+                   return Results.BadRequest("Invalid start_date format. Use YYYY-MM-DD.");
+
+               // Validate and parse end_date
+               if (!DateOnly.TryParse(end_date, out var endDate))
+                   return Results.BadRequest("Invalid end_date format. Use YYYY-MM-DD.");
+
+               // Verify start_date <= end_date
+               if (startDate > endDate)
+                   return Results.BadRequest("start_date must be less than or equal to end_date.");
+
+               // Create query with provided coachId
+               var query = new GetCoachSchedulesQuery(coachId, startDate, endDate, page, recordPerPage);
+               var result = await sender.Send(query);
+
+               return Results.Ok(result);
+           })
+           .WithName("GetPublicCoachSchedules")
+           .Produces<CoachSchedulesResponse>(StatusCodes.Status200OK)
+           .ProducesProblem(StatusCodes.Status400BadRequest)
+           .WithSummary("Get Public Coach Schedules")
+           .WithDescription("Lấy danh sách lịch làm việc của coach theo ngày với phân trang và lọc, không yêu cầu đăng nhập.")
+           .WithTags("Public", "Schedule");
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several new features and enhancements to the Coach API, including new filtering options for retrieving coaches and a new endpoint for fetching public coach schedules. The most important changes are listed below:

### New Features and Enhancements:

* Added a new method `GetCoachesBySportIdAsync` to `CoachSportRepository` to retrieve coaches by sport ID.
* Introduced new filtering options (`name`, `sportId`, `minPrice`, `maxPrice`) in the `GetCoachesEndpoint` to allow more specific queries for coaches.
* Updated the `GetCoachesQuery` record to include optional filtering parameters and modified the `GetCoachesQueryHandler` to apply these filters. [[1]](diffhunk://#diff-94337f597901382ecf2703ac54a52e538a8b7b14af4c923bc50ccba2cbb4b65fL8-R14) [[2]](diffhunk://#diff-94337f597901382ecf2703ac54a52e538a8b7b14af4c923bc50ccba2cbb4b65fR50-R116) [[3]](diffhunk://#diff-94337f597901382ecf2703ac54a52e538a8b7b14af4c923bc50ccba2cbb4b65fL81-R148)
* Added a new endpoint `/api/public/coach-schedules/{coachId:guid}` to `ViewCoachAvailabilityEndpoint` to allow fetching coach schedules without requiring authentication.

### Codebase Modifications:

* Updated the solution launch settings to include the `court coach` project for starting multiple services.
* Added the new method `GetCoachesBySportIdAsync` to the `ICoachSportRepository` interface.