### PR TITLE
Refactor chat session endpoints; rename match endpoint, update chat session retrieval logic, and add new handler for user-specific chat sessions

### DIFF
--- a/SCRMS-SEP.slnLaunch.user
+++ b/SCRMS-SEP.slnLaunch.user
@@ -47,7 +47,7 @@
     ]
   },
   {
-    "Name": "match inden court",
+    "Name": "chat match inden court",
     "Projects": [
       {
         "Path": "src\\Services\\Identity\\Identity.API\\Identity.API.csproj",
@@ -60,6 +60,10 @@
       {
         "Path": "src\\Services\\CourtBooking\\CourtBooking.API\\CourtBooking.API.csproj",
         "Action": "StartWithoutDebugging"
+      },
+      {
+        "Path": "src\\Services\\Chat\\Chat.API\\Chat.API.csproj",
+        "Action": "Start"
       }
     ]
   },

--- a/src/Services/Chat/Chat.API/Features/CreateChatSession/CreateChatSessionEndpoint.cs
+++ b/src/Services/Chat/Chat.API/Features/CreateChatSession/CreateChatSessionEndpoint.cs
@@ -1,4 +1,6 @@
-﻿namespace Chat.API.Features.CreateChatSession
+﻿using Microsoft.IdentityModel.JsonWebTokens;
+using System.Security.Claims;
+namespace Chat.API.Features.CreateChatSession
 {
     public class CreateChatSessionEndpoint : ICarterModule
     {
@@ -7,7 +9,8 @@
             app.MapPost("/api/chats", async (CreateChatSessionRequest request, ISender sender, HttpContext httpContext) =>
             {
                 // Lấy UserId từ JWT
-                var userIdClaim = httpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
+                var userIdClaim = httpContext.User.FindFirst(JwtRegisteredClaimNames.Sub)
+                                ?? httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
                 if (userIdClaim == null)
                     return Results.Unauthorized();
 

--- a/src/Services/Chat/Chat.API/Features/GetChatSessionByUsers/GetChatSessionByUsersEndpoint.cs
+++ b/src/Services/Chat/Chat.API/Features/GetChatSessionByUsers/GetChatSessionByUsersEndpoint.cs
@@ -1,0 +1,68 @@
+using System.Security.Claims;
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Chat.API.Features.GetChatSessionByUsers
+{
+    public class GetChatSessionByUsersEndpoint : ICarterModule
+    {
+        public void AddRoutes(IEndpointRouteBuilder app)
+        {
+            app.MapGet("/api/chats", async (
+                ISender sender,
+                Guid user1_id,
+                Guid user2_id,
+                HttpContext httpContext) =>
+            {
+                // Verify that user1_id matches the authenticated user's ID
+                var userIdClaim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier);
+                if (userIdClaim == null)
+                    return Results.Unauthorized();
+
+                if (!Guid.TryParse(userIdClaim.Value, out var currentUserId))
+                    return Results.BadRequest("Invalid user ID in token");
+
+                // Ensure the authenticated user is user1_id for security
+                if (currentUserId != user1_id)
+                    return Results.Forbid();
+
+                var query = new GetChatSessionByUsersQuery(user1_id, user2_id);
+                var validator = new GetChatSessionByUsersQueryValidator();
+                var validationResult = await validator.ValidateAsync(query);
+
+                if (!validationResult.IsValid)
+                {
+                    return Results.BadRequest(validationResult.Errors);
+                }
+
+                var result = await sender.Send(query);
+
+                if (result == null)
+                    return Results.NotFound();
+
+                return Results.Ok(new
+                {
+                    chat_session_id = result.ChatSessionId,
+                    user1_id = result.User1Id,
+                    user2_id = result.User2Id,
+                    created_at = result.CreatedAt,
+                    updated_at = result.UpdatedAt
+                });
+            })
+            .RequireAuthorization()
+            .WithName("GetChatSessionByUsers");
+        }
+
+        public class GetChatSessionByUsersQueryValidator : AbstractValidator<GetChatSessionByUsersQuery>
+        {
+            public GetChatSessionByUsersQueryValidator()
+            {
+                RuleFor(x => x.User1Id)
+                    .NotEmpty().WithMessage("User1Id cannot be empty.");
+                RuleFor(x => x.User2Id)
+                    .NotEmpty().WithMessage("User2Id cannot be empty.");
+            }
+        }
+    }
+}

--- a/src/Services/Chat/Chat.API/Features/GetChatSessionByUsers/GetChatSessionByUsersHandler.cs
+++ b/src/Services/Chat/Chat.API/Features/GetChatSessionByUsers/GetChatSessionByUsersHandler.cs
@@ -1,0 +1,40 @@
+using Chat.API.Data;
+using Chat.API.Data.Repositories;
+
+namespace Chat.API.Features.GetChatSessionByUsers
+{
+    public record GetChatSessionByUsersQuery(Guid User1Id, Guid User2Id) : IRequest<ChatSessionDetailResponse?>;
+
+    public record ChatSessionDetailResponse(
+        Guid ChatSessionId,
+        Guid User1Id,
+        Guid User2Id,
+        DateTime CreatedAt,
+        DateTime UpdatedAt);
+
+    public class GetChatSessionByUsersHandler : IRequestHandler<GetChatSessionByUsersQuery, ChatSessionDetailResponse?>
+    {
+        private readonly IChatSessionRepository _chatSessionRepository;
+
+        public GetChatSessionByUsersHandler(IChatSessionRepository chatSessionRepository)
+        {
+            _chatSessionRepository = chatSessionRepository;
+        }
+
+        public async Task<ChatSessionDetailResponse?> Handle(GetChatSessionByUsersQuery request, CancellationToken cancellationToken)
+        {
+            var chatSession = await _chatSessionRepository.GetChatSessionByUsersAsync(request.User1Id, request.User2Id);
+
+            if (chatSession == null)
+                return null;
+
+            return new ChatSessionDetailResponse(
+                ChatSessionId: chatSession.Id,
+                User1Id: chatSession.User1Id,
+                User2Id: chatSession.User2Id,
+                CreatedAt: chatSession.CreatedAt,
+                UpdatedAt: chatSession.UpdatedAt
+            );
+        }
+    }
+}

--- a/src/Services/Chat/Chat.API/Features/GetChatSessions/GetChatSessionsEndpoint.cs
+++ b/src/Services/Chat/Chat.API/Features/GetChatSessions/GetChatSessionsEndpoint.cs
@@ -6,7 +6,7 @@ namespace Chat.API.Features.GetChatSessions
     {
         public void AddRoutes(IEndpointRouteBuilder app)
         {
-            app.MapGet("/api/chats", async (
+            app.MapGet("/api/chats/list", async (
                 ISender sender,
                 HttpContext httpContext,
                 int page,

--- a/src/Services/Payment/Payment/Features/RevenueReport/RevenueReportHandler.cs
+++ b/src/Services/Payment/Payment/Features/RevenueReport/RevenueReportHandler.cs
@@ -40,11 +40,11 @@ namespace Payment.API.Features.RevenueReport
             DateTime? startDate = null, endDate = null;
             if (!string.IsNullOrEmpty(request.StartDate) && DateTime.TryParse(request.StartDate, out var parsedStart))
             {
-                startDate = parsedStart;
+                startDate = DateTime.SpecifyKind(parsedStart, DateTimeKind.Utc);
             }
             if (!string.IsNullOrEmpty(request.EndDate) && DateTime.TryParse(request.EndDate, out var parsedEnd))
             {
-                endDate = parsedEnd;
+                endDate = DateTime.SpecifyKind(parsedEnd, DateTimeKind.Utc);
             }
 
             // Truy vấn các giao dịch mua service package (giả sử PaymentType = "ServicePackage")


### PR DESCRIPTION
This pull request includes several changes to the chat and payment services, as well as updates to the solution launch configuration. The most important changes include adding new functionality to the chat service, modifying existing endpoints, and ensuring proper date handling in the payment service.

### Chat Service Enhancements:

* Added a new endpoint `GetChatSessionByUsers` to retrieve chat sessions between two users, including validation and authorization checks. (`src/Services/Chat/Chat.API/Features/GetChatSessionByUsers/GetChatSessionByUsersEndpoint.cs`, `src/Services/Chat/Chat.API/Features/GetChatSessionByUsers/GetChatSessionByUsersHandler.cs`) [[1]](diffhunk://#diff-e5195954f4b4e1097fb71466a8662f7adb4a0c73d6c13ca80e7a8dfb8981ed47R1-R68) [[2]](diffhunk://#diff-cbf9289f0dff2148d52fe169cb839b25d1b0632d914b5464657ac90b1b32681fR1-R40)
* Modified the `CreateChatSessionEndpoint` to handle user ID claims more robustly by checking both `JwtRegisteredClaimNames.Sub` and `ClaimTypes.NameIdentifier`. (`src/Services/Chat/Chat.API/Features/CreateChatSession/CreateChatSessionEndpoint.cs`)
* Changed the `GetChatSessionsEndpoint` route to `/api/chats/list` to avoid conflicts with the new `GetChatSessionByUsers` endpoint. (`src/Services/Chat/Chat.API/Features/GetChatSessions/GetChatSessionsEndpoint.cs`)

### Payment Service Improvements:

* Ensured that start and end dates are specified as UTC in the `RevenueReportHandler` to maintain consistency in date handling. (`src/Services/Payment/Payment/Features/RevenueReport/RevenueReportHandler.cs`)

### Solution Launch Configuration:

* Updated the solution launch configuration to include the new `Chat.API` project and modified the existing project name for clarity. (`SCRMS-SEP.slnLaunch.user`) [[1]](diffhunk://#diff-8ad9334f476536dadee57574f87d2ec7ddb399d12b5c5e142af52039d9df2013L50-R50) [[2]](diffhunk://#diff-8ad9334f476536dadee57574f87d2ec7ddb399d12b5c5e142af52039d9df2013R63-R66)…