### PR TITLE
Refactor WithdrawalRequest model to make AdminNote nullable and ensure CreatedAt is set to UTC. Add GetUserWalletBalance feature with corresponding handler and query for retrieving user wallet balance.

### DIFF
--- a/src/Services/Payment/Payment/Data/Models/WithdrawalRequest.cs
+++ b/src/Services/Payment/Payment/Data/Models/WithdrawalRequest.cs
@@ -13,7 +13,7 @@ namespace Payment.API.Data.Models
         public string AccountNumber { get; set; }
         public string AccountHolderName { get; set; }
         public string Status { get; set; } // "Pending", "Approved", "Rejected"
-        public string AdminNote { get; set; }
+        public string? AdminNote { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime? ProcessedAt { get; set; }
         public Guid? ProcessedByUserId { get; set; }

--- a/src/Services/Payment/Payment/Features/GetUserWalletBalance/GetUserWalletBalanceEndpoint.cs
+++ b/src/Services/Payment/Payment/Features/GetUserWalletBalance/GetUserWalletBalanceEndpoint.cs
@@ -1,0 +1,20 @@
+using System.Security.Claims;
+using Payment.API.Features.GetWalletBalance;
+
+namespace Payment.API.Features.GetUserWalletBalance
+{
+    public class GetUserWalletBalanceEndpoint : ICarterModule
+    {
+        public void AddRoutes(IEndpointRouteBuilder app)
+        {
+            app.MapGet("/api/admin/payments/wallet/{userId}", async (ISender sender, Guid userId) =>
+            {
+                var query = new GetWalletBalanceQuery(userId);
+                var wallet = await sender.Send(query);
+                return Results.Ok(wallet);
+            })
+            .RequireAuthorization("Admin")
+            .WithName("GetUserWalletBalance");
+        }
+    }
+}

--- a/src/Services/Payment/Payment/Features/GetUserWalletBalance/GetUserWalletBalanceHandler.cs
+++ b/src/Services/Payment/Payment/Features/GetUserWalletBalance/GetUserWalletBalanceHandler.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Payment.API.Data.Models;
+using Payment.API.Data.Repositories;
+
+namespace Payment.API.Features.GetUserWalletBalance
+{
+    public class GetUserWalletBalanceHandler : IRequestHandler<GetUserWalletBalanceQuery, UserWallet>
+    {
+        private readonly IUserWalletRepository _userWalletRepository;
+
+        public GetUserWalletBalanceHandler(IUserWalletRepository userWalletRepository)
+        {
+            _userWalletRepository = userWalletRepository;
+        }
+
+        public async Task<UserWallet> Handle(GetUserWalletBalanceQuery request, CancellationToken cancellationToken)
+        {
+            var wallet = await _userWalletRepository.GetUserWalletByUserIdAsync(request.UserId, cancellationToken);
+            if (wallet == null)
+                return new UserWallet
+                {
+                    UserId = request.UserId,
+                    Balance = 0,
+                    UpdatedAt = DateTime.UtcNow
+                };
+
+            return wallet;
+        }
+    }
+}

--- a/src/Services/Payment/Payment/Features/GetUserWalletBalance/GetUserWalletBalanceQuery.cs
+++ b/src/Services/Payment/Payment/Features/GetUserWalletBalance/GetUserWalletBalanceQuery.cs
@@ -1,0 +1,8 @@
+using System;
+using MediatR;
+using Payment.API.Data.Models;
+
+namespace Payment.API.Features.GetUserWalletBalance
+{
+    public record GetUserWalletBalanceQuery(Guid UserId) : IRequest<UserWallet>;
+}

--- a/src/Services/Payment/Payment/Features/ProcessWithdrawalRequest/ProcessWithdrawalRequestHandler.cs
+++ b/src/Services/Payment/Payment/Features/ProcessWithdrawalRequest/ProcessWithdrawalRequestHandler.cs
@@ -54,6 +54,9 @@ namespace Payment.API.Features.ProcessWithdrawalRequest
             withdrawalRequest.ProcessedAt = DateTime.UtcNow;
             withdrawalRequest.ProcessedByUserId = request.AdminUserId;
 
+            // Đảm bảo CreatedAt luôn là UTC
+            withdrawalRequest.CreatedAt = DateTime.SpecifyKind(withdrawalRequest.CreatedAt, DateTimeKind.Utc);
+
             await _withdrawalRequestRepository.UpdateAsync(withdrawalRequest, cancellationToken);
 
             // Nếu phê duyệt, cập nhật số dư ví và tạo giao dịch

--- a/src/Services/Payment/Payment/Migrations/20250409095125_InitialCreate.Designer.cs
+++ b/src/Services/Payment/Payment/Migrations/20250409095125_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using Payment.API.Data;
 namespace Payment.API.Migrations
 {
     [DbContext(typeof(PaymentDbContext))]
-    [Migration("20250409044250_InitialCreate")]
+    [Migration("20250409095125_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -122,7 +122,6 @@ namespace Payment.API.Migrations
                         .HasColumnType("text");
 
                     b.Property<string>("AdminNote")
-                        .IsRequired()
                         .HasColumnType("text");
 
                     b.Property<decimal>("Amount")

--- a/src/Services/Payment/Payment/Migrations/20250409095125_InitialCreate.cs
+++ b/src/Services/Payment/Payment/Migrations/20250409095125_InitialCreate.cs
@@ -68,7 +68,7 @@ namespace Payment.API.Migrations
                     AccountNumber = table.Column<string>(type: "text", nullable: false),
                     AccountHolderName = table.Column<string>(type: "text", nullable: false),
                     Status = table.Column<string>(type: "text", nullable: false),
-                    AdminNote = table.Column<string>(type: "text", nullable: false),
+                    AdminNote = table.Column<string>(type: "text", nullable: true),
                     CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     ProcessedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
                     ProcessedByUserId = table.Column<Guid>(type: "uuid", nullable: true)

--- a/src/Services/Payment/Payment/Migrations/PaymentDbContextModelSnapshot.cs
+++ b/src/Services/Payment/Payment/Migrations/PaymentDbContextModelSnapshot.cs
@@ -119,7 +119,6 @@ namespace Payment.API.Migrations
                         .HasColumnType("text");
 
                     b.Property<string>("AdminNote")
-                        .IsRequired()
                         .HasColumnType("text");
 
                     b.Property<decimal>("Amount")


### PR DESCRIPTION
This pull request introduces several changes to the `Payment` service, primarily focusing on adding a new feature to get user wallet balances, updating the `WithdrawalRequest` model, and modifying migration files. Here are the most important changes:

### New Feature: Get User Wallet Balance

* [`src/Services/Payment/Payment/Features/GetUserWalletBalance/GetUserWalletBalanceEndpoint.cs`](diffhunk://#diff-135b7118a87848aeab8dffeedc2408ec41fd622e10265634f26b131ea3592c68R1-R20): Added a new endpoint to get the wallet balance of a user by their user ID. This endpoint requires admin authorization.
* [`src/Services/Payment/Payment/Features/GetUserWalletBalance/GetUserWalletBalanceHandler.cs`](diffhunk://#diff-c57e3be1902b3db3d3f8f4fe885b0506946982ff20764f8cb3b33f03ce51f120R1-R33): Implemented the handler for the new endpoint to fetch the user's wallet balance from the repository.
* [`src/Services/Payment/Payment/Features/GetUserWalletBalance/GetUserWalletBalanceQuery.cs`](diffhunk://#diff-8dbdd9de46ca1a73708c3ed8bfcc5a151a27941d38c8aabbed61f639bf33c348R1-R8): Added a new query that represents the request to get a user's wallet balance.

### Model Update: `WithdrawalRequest`

* [`src/Services/Payment/Payment/Data/Models/WithdrawalRequest.cs`](diffhunk://#diff-1be5a3c3be889a2e56010c1f740ec6d711478bd2dced6d3915d655904f51e96eL16-R16): Updated the `AdminNote` property to be nullable.

### Migration Updates

* [`src/Services/Payment/Payment/Migrations/20250409095125_InitialCreate.Designer.cs`](diffhunk://#diff-4e2417cc5c9e6462811de56d6885c965f609db67f9475e7eccb5730899e7c733L15-R15): Renamed the migration file and updated the `AdminNote` property to be nullable in the model snapshot. [[1]](diffhunk://#diff-4e2417cc5c9e6462811de56d6885c965f609db67f9475e7eccb5730899e7c733L15-R15) [[2]](diffhunk://#diff-4e2417cc5c9e6462811de56d6885c965f609db67f9475e7eccb5730899e7c733L125)
* [`src/Services/Payment/Payment/Migrations/20250409095125_InitialCreate.cs`](diffhunk://#diff-9afaa6e575213e5b9909fcbc5a42c3438b59a4c76e4fec427cbbb6ba6709cce0L71-R71): Modified the `AdminNote` column to be nullable in the migration script.
* [`src/Services/Payment/Payment/Migrations/PaymentDbContextModelSnapshot.cs`](diffhunk://#diff-2bfe4ceae5654711d2eb24a46113bbd4ce51fa07ed808af886964077177f0c7eL122): Updated the model snapshot to reflect the nullable `AdminNote` property.

### Other Changes

* [`src/Services/Payment/Payment/Features/ProcessWithdrawalRequest/ProcessWithdrawalRequestHandler.cs`](diffhunk://#diff-da469896f2097716c2d9c6be56f02b238bcd3b7200f16bd910be39fbcffaca29R57-R59): Ensured that the `CreatedAt` property is always set to UTC when processing a withdrawal request.