### PR TITLE
Branch dev

### DIFF
--- a/src/Services/Coach/Coach.API.Tests/Packages/DeletePackageCommandHandlerTests.cs
+++ b/src/Services/Coach/Coach.API.Tests/Packages/DeletePackageCommandHandlerTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Coach.API.Data;
+using Coach.API.Data.Models;
+using Coach.API.Data.Repositories;
+using Coach.API.Features.Packages.DeletePackage;
+using BuildingBlocks.Exceptions;
+using Moq;
+using Xunit;
+using FluentValidation.TestHelper;
+
+namespace Coach.API.Tests.Packages
+{
+    public class DeletePackageCommandHandlerTests
+    {
+        // Normal cases
+        [Fact]
+        public async Task Handle_ValidDelete_DeactivatesPackageSuccessfully()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var coachId = Guid.NewGuid();
+
+            var existingPackage = new CoachPackage
+            {
+                Id = packageId,
+                CoachId = coachId,
+                Name = "Test Package",
+                Description = "Test Description",
+                Price = 100m,
+                SessionCount = 5,
+                Status = "active"
+            };
+
+            var command = new DeletePackageCommand(
+                PackageId: packageId,
+                CoachId: coachId
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPackage);
+            mockPackageRepo.Setup(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var mockContext = new Mock<CoachDbContext>();
+            mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var handler = new DeletePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            mockPackageRepo.Verify(r => r.UpdateCoachPackageAsync(It.Is<CoachPackage>(p =>
+                p.Id == packageId &&
+                p.Status == "inactive"),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            mockContext.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+            Assert.Equal(packageId, result.Id);
+            Assert.Equal("inactive", result.Status);
+            Assert.Equal("Package successfully deactivated", result.Message);
+        }
+
+        [Fact]
+        public async Task Handle_AlreadyInactivePackage_StillReturnsSuccess()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var coachId = Guid.NewGuid();
+
+            var existingPackage = new CoachPackage
+            {
+                Id = packageId,
+                CoachId = coachId,
+                Name = "Test Package",
+                Description = "Test Description",
+                Price = 100m,
+                SessionCount = 5,
+                Status = "inactive"  // Already inactive
+            };
+
+            var command = new DeletePackageCommand(
+                PackageId: packageId,
+                CoachId: coachId
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPackage);
+            mockPackageRepo.Setup(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var mockContext = new Mock<CoachDbContext>();
+            mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var handler = new DeletePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            mockPackageRepo.Verify(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            Assert.Equal(packageId, result.Id);
+            Assert.Equal("inactive", result.Status);
+        }
+
+        // Abnormal cases
+        [Fact]
+        public async Task Handle_PackageNotFound_ThrowsNotFoundException()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var coachId = Guid.NewGuid();
+
+            var command = new DeletePackageCommand(
+                PackageId: packageId,
+                CoachId: coachId
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CoachPackage)null);
+
+            var mockContext = new Mock<CoachDbContext>();
+
+            var handler = new DeletePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NotFoundException>(() =>
+                handler.Handle(command, CancellationToken.None));
+
+            mockPackageRepo.Verify(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_UnauthorizedCoach_ThrowsUnauthorizedException()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var packageOwnerId = Guid.NewGuid();
+            var differentCoachId = Guid.NewGuid();
+
+            var existingPackage = new CoachPackage
+            {
+                Id = packageId,
+                CoachId = packageOwnerId,  // Original coach
+                Name = "Test Package",
+                Description = "Test Description",
+                Price = 100m,
+                SessionCount = 5,
+                Status = "active"
+            };
+
+            var command = new DeletePackageCommand(
+                PackageId: packageId,
+                CoachId: differentCoachId  // Different coach trying to delete
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPackage);
+
+            var mockContext = new Mock<CoachDbContext>();
+
+            var handler = new DeletePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+                handler.Handle(command, CancellationToken.None));
+
+            mockPackageRepo.Verify(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        // Boundary cases
+        [Fact]
+        public async Task Handle_EmptyDescription_DeactivatesPackageSuccessfully()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var coachId = Guid.NewGuid();
+
+            var existingPackage = new CoachPackage
+            {
+                Id = packageId,
+                CoachId = coachId,
+                Name = "Test Package",
+                Description = "",  // Empty description
+                Price = 100m,
+                SessionCount = 5,
+                Status = "active"
+            };
+
+            var command = new DeletePackageCommand(
+                PackageId: packageId,
+                CoachId: coachId
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPackage);
+            mockPackageRepo.Setup(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var mockContext = new Mock<CoachDbContext>();
+            mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var handler = new DeletePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(packageId, result.Id);
+            Assert.Equal("inactive", result.Status);
+        }
+
+        [Fact]
+        public async Task Handle_ZeroPriceAndSessionCount_DeactivatesPackageSuccessfully()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var coachId = Guid.NewGuid();
+
+            var existingPackage = new CoachPackage
+            {
+                Id = packageId,
+                CoachId = coachId,
+                Name = "Test Package",
+                Description = "Test Description",
+                Price = 0,  // Zero price
+                SessionCount = 0,  // Zero sessions
+                Status = "active"
+            };
+
+            var command = new DeletePackageCommand(
+                PackageId: packageId,
+                CoachId: coachId
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPackage);
+            mockPackageRepo.Setup(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var mockContext = new Mock<CoachDbContext>();
+            mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var handler = new DeletePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(packageId, result.Id);
+            Assert.Equal("inactive", result.Status);
+        }
+    }
+}

--- a/src/Services/Coach/Coach.API.Tests/Packages/UpdatePackageCommandHandlerTests.cs
+++ b/src/Services/Coach/Coach.API.Tests/Packages/UpdatePackageCommandHandlerTests.cs
@@ -1,0 +1,455 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Coach.API.Data;
+using Coach.API.Data.Models;
+using Coach.API.Data.Repositories;
+using Coach.API.Features.Packages.UpdatePackage;
+using BuildingBlocks.Exceptions;
+using Moq;
+using Xunit;
+using FluentValidation;
+using FluentValidation.TestHelper;
+
+namespace Coach.API.Tests.Packages
+{
+    public class UpdatePackageCommandHandlerTests
+    {
+        // Normal cases
+        [Fact]
+        public async Task Handle_ValidPackageUpdate_UpdatesPackageSuccessfully()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var coachId = Guid.NewGuid();
+
+            var existingPackage = new CoachPackage
+            {
+                Id = packageId,
+                CoachId = coachId,
+                Name = "Original Name",
+                Description = "Original Description",
+                Price = 100m,
+                SessionCount = 5,
+                Status = "active"
+            };
+
+            var command = new UpdatePackageCommand(
+                PackageId: packageId,
+                CoachId: coachId,
+                Name: "Updated Name",
+                Description: "Updated Description",
+                Price: 150m,
+                SessionCount: 10,
+                Status: "active"
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPackage);
+            mockPackageRepo.Setup(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var mockContext = new Mock<CoachDbContext>();
+            mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            var handler = new UpdatePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            mockPackageRepo.Verify(r => r.UpdateCoachPackageAsync(It.Is<CoachPackage>(p =>
+                p.Id == packageId &&
+                p.Name == "Updated Name" &&
+                p.Description == "Updated Description" &&
+                p.Price == 150m &&
+                p.SessionCount == 10 &&
+                p.Status == "active"),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            mockContext.Verify(c => c.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+            Assert.Equal(packageId, result.Id);
+            Assert.Equal("Updated Name", result.Name);
+            Assert.Equal("Updated Description", result.Description);
+            Assert.Equal(150m, result.Price);
+            Assert.Equal(10, result.SessionCount);
+            Assert.Equal("active", result.Status);
+        }
+
+        [Fact]
+        public async Task Handle_ChangeStatusFromActiveToInactive_UpdatesPackageSuccessfully()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var coachId = Guid.NewGuid();
+
+            var existingPackage = new CoachPackage
+            {
+                Id = packageId,
+                CoachId = coachId,
+                Name = "Test Package",
+                Description = "Test Description",
+                Price = 100m,
+                SessionCount = 5,
+                Status = "active"
+            };
+
+            var command = new UpdatePackageCommand(
+                PackageId: packageId,
+                CoachId: coachId,
+                Name: "Test Package",
+                Description: "Test Description",
+                Price: 100m,
+                SessionCount: 5,
+                Status: "inactive"
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPackage);
+            mockPackageRepo.Setup(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var mockContext = new Mock<CoachDbContext>();
+            mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var handler = new UpdatePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            mockPackageRepo.Verify(r => r.UpdateCoachPackageAsync(It.Is<CoachPackage>(p =>
+                p.Status == "inactive"),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            Assert.Equal("inactive", result.Status);
+        }
+
+        // Abnormal cases
+        [Fact]
+        public async Task Handle_PackageNotFound_ThrowsNotFoundException()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var command = new UpdatePackageCommand(
+                PackageId: packageId,
+                CoachId: Guid.NewGuid(),
+                Name: "Test",
+                Description: "Test",
+                Price: 100m,
+                SessionCount: 5,
+                Status: "active"
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((CoachPackage)null);
+
+            var mockContext = new Mock<CoachDbContext>();
+            var handler = new UpdatePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NotFoundException>(() =>
+                handler.Handle(command, CancellationToken.None));
+
+            mockPackageRepo.Verify(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Handle_UnauthorizedCoachId_ThrowsUnauthorizedException()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var packageOwnerId = Guid.NewGuid();
+            var differentCoachId = Guid.NewGuid();
+
+            var existingPackage = new CoachPackage
+            {
+                Id = packageId,
+                CoachId = packageOwnerId,  // Original coach
+                Name = "Test Package",
+                Description = "Test Description",
+                Price = 100m,
+                SessionCount = 5
+            };
+
+            var command = new UpdatePackageCommand(
+                PackageId: packageId,
+                CoachId: differentCoachId,  // Different coach trying to update
+                Name: "Updated Package",
+                Description: "Updated Description",
+                Price: 150m,
+                SessionCount: 10,
+                Status: "active"
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPackage);
+
+            var mockContext = new Mock<CoachDbContext>();
+            var handler = new UpdatePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+                handler.Handle(command, CancellationToken.None));
+
+            mockPackageRepo.Verify(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        // Validation tests
+        [Fact]
+        public void Validate_EmptyPackageId_ShouldFailValidation()
+        {
+            // Arrange
+            var command = new UpdatePackageCommand(
+                PackageId: Guid.Empty,
+                CoachId: Guid.NewGuid(),
+                Name: "Test",
+                Description: "Test",
+                Price: 100m,
+                SessionCount: 5,
+                Status: "active"
+            );
+            var validator = new UpdatePackageCommandValidator();
+
+            // Act
+            var result = validator.TestValidate(command);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.PackageId)
+                .WithErrorMessage("PackageId is required");
+        }
+
+        [Fact]
+        public void Validate_EmptyCoachId_ShouldFailValidation()
+        {
+            // Arrange
+            var command = new UpdatePackageCommand(
+                PackageId: Guid.NewGuid(),
+                CoachId: Guid.Empty,
+                Name: "Test",
+                Description: "Test",
+                Price: 100m,
+                SessionCount: 5,
+                Status: "active"
+            );
+            var validator = new UpdatePackageCommandValidator();
+
+            // Act
+            var result = validator.TestValidate(command);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.CoachId)
+                .WithErrorMessage("CoachId is required");
+        }
+
+        [Fact]
+        public void Validate_EmptyName_ShouldFailValidation()
+        {
+            // Arrange
+            var command = new UpdatePackageCommand(
+                PackageId: Guid.NewGuid(),
+                CoachId: Guid.NewGuid(),
+                Name: "",
+                Description: "Test",
+                Price: 100m,
+                SessionCount: 5,
+                Status: "active"
+            );
+            var validator = new UpdatePackageCommandValidator();
+
+            // Act
+            var result = validator.TestValidate(command);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Name)
+                .WithErrorMessage("Name must not be empty");
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Validate_InvalidPrice_ShouldFailValidation(decimal price)
+        {
+            // Arrange
+            var command = new UpdatePackageCommand(
+                PackageId: Guid.NewGuid(),
+                CoachId: Guid.NewGuid(),
+                Name: "Test",
+                Description: "Test",
+                Price: price,
+                SessionCount: 5,
+                Status: "active"
+            );
+            var validator = new UpdatePackageCommandValidator();
+
+            // Act
+            var result = validator.TestValidate(command);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Price)
+                .WithErrorMessage("Price must be greater than 0");
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Validate_InvalidSessionCount_ShouldFailValidation(int sessionCount)
+        {
+            // Arrange
+            var command = new UpdatePackageCommand(
+                PackageId: Guid.NewGuid(),
+                CoachId: Guid.NewGuid(),
+                Name: "Test",
+                Description: "Test",
+                Price: 100m,
+                SessionCount: sessionCount,
+                Status: "active"
+            );
+            var validator = new UpdatePackageCommandValidator();
+
+            // Act
+            var result = validator.TestValidate(command);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.SessionCount)
+                .WithErrorMessage("SessionCount must be greater than 0");
+        }
+
+        [Theory]
+        [InlineData("pending")]
+        [InlineData("cancelled")]
+        [InlineData("")]
+        public void Validate_InvalidStatus_ShouldFailValidation(string status)
+        {
+            // Arrange
+            var command = new UpdatePackageCommand(
+                PackageId: Guid.NewGuid(),
+                CoachId: Guid.NewGuid(),
+                Name: "Test",
+                Description: "Test",
+                Price: 100m,
+                SessionCount: 5,
+                Status: status
+            );
+            var validator = new UpdatePackageCommandValidator();
+
+            // Act
+            var result = validator.TestValidate(command);
+
+            // Assert
+            result.ShouldHaveValidationErrorFor(x => x.Status)
+                .WithErrorMessage("Status must be either 'active' or 'inactive'");
+        }
+
+        // Boundary cases
+        [Fact]
+        public async Task Handle_EmptyDescription_UpdatesPackageSuccessfully()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var coachId = Guid.NewGuid();
+
+            var existingPackage = new CoachPackage
+            {
+                Id = packageId,
+                CoachId = coachId,
+                Name = "Test Package",
+                Description = "Original Description",
+                Price = 100m,
+                SessionCount = 5,
+                Status = "active"
+            };
+
+            var command = new UpdatePackageCommand(
+                PackageId: packageId,
+                CoachId: coachId,
+                Name: "Test Package",
+                Description: "",  // Empty description
+                Price: 100m,
+                SessionCount: 5,
+                Status: "active"
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPackage);
+            mockPackageRepo.Setup(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var mockContext = new Mock<CoachDbContext>();
+            mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var handler = new UpdatePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            mockPackageRepo.Verify(r => r.UpdateCoachPackageAsync(It.Is<CoachPackage>(p =>
+                p.Description == ""),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            Assert.Equal("", result.Description);
+        }
+
+        [Fact]
+        public async Task Handle_MaxPriceAndSessionCount_UpdatesPackageSuccessfully()
+        {
+            // Arrange
+            var packageId = Guid.NewGuid();
+            var coachId = Guid.NewGuid();
+
+            var existingPackage = new CoachPackage
+            {
+                Id = packageId,
+                CoachId = coachId,
+                Name = "Test Package",
+                Description = "Test Description",
+                Price = 100m,
+                SessionCount = 5,
+                Status = "active"
+            };
+
+            var command = new UpdatePackageCommand(
+                PackageId: packageId,
+                CoachId: coachId,
+                Name: "Test Package",
+                Description: "Test Description",
+                Price: decimal.MaxValue,  // Max price
+                SessionCount: int.MaxValue,  // Max sessions
+                Status: "active"
+            );
+
+            var mockPackageRepo = new Mock<ICoachPackageRepository>();
+            mockPackageRepo.Setup(r => r.GetCoachPackageByIdAsync(packageId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(existingPackage);
+            mockPackageRepo.Setup(r => r.UpdateCoachPackageAsync(It.IsAny<CoachPackage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var mockContext = new Mock<CoachDbContext>();
+            mockContext.Setup(c => c.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var handler = new UpdatePackageCommandHandler(mockPackageRepo.Object, mockContext.Object);
+
+            // Act
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            mockPackageRepo.Verify(r => r.UpdateCoachPackageAsync(It.Is<CoachPackage>(p =>
+                p.Price == decimal.MaxValue &&
+                p.SessionCount == int.MaxValue),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            Assert.Equal(decimal.MaxValue, result.Price);
+            Assert.Equal(int.MaxValue, result.SessionCount);
+        }
+    }
+}

--- a/src/Services/Identity/Identity.Application/Identity/Commands/Register/RegisterUserHandler.cs
+++ b/src/Services/Identity/Identity.Application/Identity/Commands/Register/RegisterUserHandler.cs
@@ -15,7 +15,7 @@ namespace Identity.Application.Identity.Commands.Register
         private readonly IHttpClientFactory? _httpClientFactory;
 
         public RegisterUserHandler(
-            IUserRepository userRepository, 
+            IUserRepository userRepository,
             IOptions<EndpointSettings> endpointSettings,
             IHttpClientFactory? httpClientFactory = null)
         {
@@ -77,7 +77,7 @@ namespace Identity.Application.Identity.Commands.Register
 
             return new RegisterUserResult(user.Id);
         }
-        
+
         /// <summary>
         /// Generate the token to encrypt the data for sending
         /// </summary>

--- a/src/Services/Identity/Identity.Test/Application/Identity/Commands/UpdateProfileHandlerTests.cs
+++ b/src/Services/Identity/Identity.Test/Application/Identity/Commands/UpdateProfileHandlerTests.cs
@@ -53,12 +53,12 @@ namespace Identity.Test.Application.Identity.Commands
 
             var handler = new UpdateProfileHandler(_userRepositoryMock.Object, _imageKitServiceMock.Object);
             var command = new UpdateProfileCommand(
-                user.Id, 
-                "NewFirst", 
-                "NewLast", 
-                "+987654321", 
-                DateTime.UtcNow.AddYears(-20), 
-                "Male", 
+                user.Id,
+                "NewFirst",
+                "NewLast",
+                "+987654321",
+                DateTime.UtcNow.AddYears(-20),
+                "Male",
                 "Hello!"
             );
 
@@ -79,12 +79,12 @@ namespace Identity.Test.Application.Identity.Commands
                 .ReturnsAsync((User?)null);
             var handler = new UpdateProfileHandler(_userRepositoryMock.Object, _imageKitServiceMock.Object);
             var command = new UpdateProfileCommand(
-                Guid.NewGuid(), 
-                "NewFirst", 
-                "NewLast", 
-                "+987654321", 
-                DateTime.UtcNow.AddYears(-20), 
-                "Male", 
+                Guid.NewGuid(),
+                "NewFirst",
+                "NewLast",
+                "+987654321",
+                DateTime.UtcNow.AddYears(-20),
+                "Male",
                 "Hello!"
             );
 
@@ -94,7 +94,7 @@ namespace Identity.Test.Application.Identity.Commands
             // Assert
             await act.Should().ThrowAsync<DomainException>().WithMessage("User not found");
         }
-        
+
         [Fact]
         public async Task Handle_ShouldUpdateImagesSuccessfully()
         {
@@ -112,36 +112,36 @@ namespace Identity.Test.Application.Identity.Commands
                 Email = "test@example.com",
                 CreatedAt = DateTime.UtcNow
             };
-            
+
             // Add existing images to user
             user.SetImageUrlsList(existingImageUrls);
-            
+
             _userRepositoryMock.Setup(x => x.GetUserByIdAsync(userId))
                 .ReturnsAsync(user);
             _userRepositoryMock.Setup(x => x.UpdateUserAsync(user))
                 .ReturnsAsync(IdentityResult.Success);
             _userRepositoryMock.Setup(x => x.GetRolesAsync(user))
                 .ReturnsAsync(new List<string> { "User" });
-            
+
             // Setup for image deletion
             _imageKitServiceMock.Setup(x => x.DeleteFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
-            
+
             // Create a mock IFormFile for the avatar
             var mockAvatarFile = CreateMockFormFile("avatar.jpg", "image/jpeg");
-            
+
             // Setup for new image uploads
             _imageKitServiceMock.Setup(x => x.UploadFileAsync(It.IsAny<IFormFile>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync("new-avatar.jpg");
-            
+
             var handler = new UpdateProfileHandler(_userRepositoryMock.Object, _imageKitServiceMock.Object);
             var command = new UpdateProfileCommand(
-                userId, 
-                "NewFirst", 
-                "NewLast", 
-                "+987654321", 
-                DateTime.UtcNow.AddYears(-20), 
-                "Male", 
+                userId,
+                "NewFirst",
+                "NewLast",
+                "+987654321",
+                DateTime.UtcNow.AddYears(-20),
+                "Male",
                 "Hello!",
                 mockAvatarFile,
                 null,
@@ -158,17 +158,17 @@ namespace Identity.Test.Application.Identity.Commands
             result.ImageUrls.Should().Contain("new-avatar.jpg");
             result.ImageUrls.Should().Contain("image1.jpg");
             result.ImageUrls.Should().NotContain("image2.jpg");
-            
+
             // Verify image deletion was called
             _imageKitServiceMock.Verify(x => x.DeleteFileAsync("image2.jpg", It.IsAny<CancellationToken>()), Times.Once);
         }
-        
+
         // Helper method to create mock IFormFile
         private IFormFile CreateMockFormFile(string fileName, string contentType)
         {
             var content = "mock file content";
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
-            
+
             var formFile = new Mock<IFormFile>();
             formFile.Setup(f => f.FileName).Returns(fileName);
             formFile.Setup(f => f.ContentType).Returns(contentType);
@@ -176,7 +176,7 @@ namespace Identity.Test.Application.Identity.Commands
             formFile.Setup(f => f.OpenReadStream()).Returns(stream);
             formFile.Setup(f => f.CopyToAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
-            
+
             return formFile.Object;
         }
     }

--- a/src/Services/Identity/Identity.Test/Application/Identity/Queries/GetProfileHandlerTests.cs
+++ b/src/Services/Identity/Identity.Test/Application/Identity/Queries/GetProfileHandlerTests.cs
@@ -40,7 +40,7 @@ namespace Identity.Test.Application.Identity.Queries
             };
             _userRepositoryMock.Setup(x => x.GetUserByIdAsync(user.Id))
                 .ReturnsAsync(user);
-            
+
             // Setup GetRolesAsync to return a non-null collection (empty list if no roles)
             _userRepositoryMock.Setup(x => x.GetRolesAsync(user))
                 .ReturnsAsync(new List<string>());
@@ -75,7 +75,7 @@ namespace Identity.Test.Application.Identity.Queries
             // Assert
             await act.Should().ThrowAsync<DomainException>().WithMessage("User not found");
         }
-        
+
         [Fact]
         public async Task Handle_ShouldIncludeRoles_WhenUserHasRoles()
         {
@@ -91,12 +91,12 @@ namespace Identity.Test.Application.Identity.Queries
                 Gender = Gender.Female,
                 CreatedAt = DateTime.UtcNow
             };
-            
+
             var roles = new List<string> { "Admin", "User" };
-            
+
             _userRepositoryMock.Setup(x => x.GetUserByIdAsync(user.Id))
                 .ReturnsAsync(user);
-                
+
             _userRepositoryMock.Setup(x => x.GetRolesAsync(user))
                 .ReturnsAsync(roles);
 

--- a/src/Services/Identity/Identity.Test/Application/Identity/Queries/GetUserByIdQueryHandlerTests.cs
+++ b/src/Services/Identity/Identity.Test/Application/Identity/Queries/GetUserByIdQueryHandlerTests.cs
@@ -40,10 +40,10 @@ namespace Identity.Test.Application.Identity.Queries
                 CreatedAt = DateTime.UtcNow,
                 IsDeleted = false
             };
-            
+
             _userRepositoryMock.Setup(x => x.GetUserByIdAsync(user.Id))
                 .ReturnsAsync(user);
-            
+
             // Setup GetRolesAsync to return a non-null collection (empty list if no roles)
             _userRepositoryMock.Setup(x => x.GetRolesAsync(user))
                 .ReturnsAsync(new List<string>());
@@ -76,7 +76,7 @@ namespace Identity.Test.Application.Identity.Queries
             // Assert
             result.Should().BeNull();
         }
-        
+
         [Fact]
         public async Task Handle_ShouldReturnUserProfileDto_WhenUserExistsForProfileQuery()
         {
@@ -95,7 +95,7 @@ namespace Identity.Test.Application.Identity.Queries
                 CreatedAt = DateTime.UtcNow,
                 IsDeleted = false
             };
-            
+
             _userRepositoryMock.Setup(x => x.GetUserByIdAsync(userId))
                 .ReturnsAsync(user);
 


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the `DeletePackageCommandHandler` in the `Coach.API` service. The tests cover various scenarios including normal, abnormal, and boundary cases to ensure the correct behavior of the handler when deleting a package.

### Unit Tests for `DeletePackageCommandHandler`:

* Added tests to verify successful deactivation of a package when a valid delete command is issued.
* Added tests to handle the scenario where the package is already inactive but the delete command still returns success.
* Added tests to ensure that a `NotFoundException` is thrown when attempting to delete a non-existent package.
* Added tests to verify that an `UnauthorizedAccessException` is thrown when a coach who does not own the package attempts to delete it.
* Added boundary tests to confirm successful deactivation of packages with edge case values such as empty descriptions or zero price and session count.