### PR TITLE
fix: Update service package name search to be case-insensitive

### DIFF
--- a/src/Services/Identity/Identity.Application/ServicePackages/Queries/GetServicePackages/GetServicePackagesHandler.cs
+++ b/src/Services/Identity/Identity.Application/ServicePackages/Queries/GetServicePackages/GetServicePackagesHandler.cs
@@ -22,7 +22,7 @@ namespace Identity.Application.ServicePackages.Queries.GetServicePackages
             // Áp dụng search theo tên
             if (!string.IsNullOrWhiteSpace(query.Search))
             {
-                packagesQuery = packagesQuery.Where(p => p.Name.Contains(query.Search, StringComparison.OrdinalIgnoreCase));
+                packagesQuery = packagesQuery.Where(p => p.Name.ToLower().Contains(query.Search.ToLower()));
             }
 
             // Áp dụng filter theo AssociatedRole


### PR DESCRIPTION
This pull request updates the `GetServicePackagesHandler` to improve the search functionality by making it case-insensitive.

* [`src/Services/Identity/Identity.Application/ServicePackages/Queries/GetServicePackages/GetServicePackagesHandler.cs`](diffhunk://#diff-0e04432673ba85e7a246b2d00357de33b7c0680babf1bfb7d85be5b65d79d5bcL25-R25): Modified the `packagesQuery` search filter to use `StringComparison.OrdinalIgnoreCase`, ensuring that searches are no longer case-sensitive.