### PR TITLE
feat: Implement court owner booking cancellation with 100% refund and authorization checks

### DIFF
--- a/src/Services/Coach/Coach.API/Features/Bookings/CancelBooking/CancelCoachBookingCommandHandler.cs
+++ b/src/Services/Coach/Coach.API/Features/Bookings/CancelBooking/CancelCoachBookingCommandHandler.cs
@@ -70,12 +70,6 @@ namespace Coach.API.Features.Bookings.CancelBooking
             {
                 throw new InvalidOperationException("The booking is already cancelled");
             }
-
-            if (booking.Status == "completed")
-            {
-                throw new InvalidOperationException("Cannot cancel a completed booking");
-            }
-
             // Check if the user is authorized to cancel this booking
             bool isAuthorized = false;
 

--- a/src/Services/CourtBooking/CourtBooking.Application/BookingManagement/Command/CancelBookingByOwner/CancelBookingByOwnerCommand.cs
+++ b/src/Services/CourtBooking/CourtBooking.Application/BookingManagement/Command/CancelBookingByOwner/CancelBookingByOwnerCommand.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+using MediatR;
+using System;
+
+namespace CourtBooking.Application.BookingManagement.Command.CancelBookingByOwner
+{
+    public record CancelBookingByOwnerCommand(
+        Guid BookingId,
+        string CancellationReason,
+        DateTime RequestedAt,
+        Guid OwnerId
+    ) : IRequest<CancelBookingByOwnerResult>;
+
+    public record CancelBookingByOwnerResult(
+        Guid BookingId,
+        string Status,
+        decimal RefundAmount,
+        string Message
+    );
+
+    public class CancelBookingByOwnerCommandValidator : AbstractValidator<CancelBookingByOwnerCommand>
+    {
+        public CancelBookingByOwnerCommandValidator()
+        {
+            RuleFor(c => c.BookingId).NotEmpty();
+            RuleFor(c => c.CancellationReason).NotEmpty().MaximumLength(500);
+            RuleFor(c => c.RequestedAt).NotEmpty();
+            RuleFor(c => c.OwnerId).NotEmpty();
+        }
+    }
+}

--- a/src/Services/CourtBooking/CourtBooking.Application/BookingManagement/Command/CancelBookingByOwner/CancelBookingByOwnerCommandHandler.cs
+++ b/src/Services/CourtBooking/CourtBooking.Application/BookingManagement/Command/CancelBookingByOwner/CancelBookingByOwnerCommandHandler.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BuildingBlocks.Exceptions;
+using BuildingBlocks.Messaging.Outbox;
+using BuildingBlocks.Messaging.Events;
+using CourtBooking.Application.Data;
+using CourtBooking.Application.Data.Repositories;
+using CourtBooking.Domain.Enums;
+using CourtBooking.Domain.Events;
+using CourtBooking.Domain.ValueObjects;
+using MediatR;
+
+namespace CourtBooking.Application.BookingManagement.Command.CancelBookingByOwner
+{
+    public class CancelBookingByOwnerCommandHandler : IRequestHandler<CancelBookingByOwnerCommand, CancelBookingByOwnerResult>
+    {
+        private readonly IBookingRepository _bookingRepository;
+        private readonly ICourtRepository _courtRepository;
+        private readonly ISportCenterRepository _sportCenterRepository;
+        private readonly IOutboxService _outboxService;
+        private readonly IApplicationDbContext _dbContext;
+
+        public CancelBookingByOwnerCommandHandler(
+            IBookingRepository bookingRepository,
+            ICourtRepository courtRepository,
+            ISportCenterRepository sportCenterRepository,
+            IOutboxService outboxService,
+            IApplicationDbContext dbContext)
+        {
+            _bookingRepository = bookingRepository;
+            _courtRepository = courtRepository;
+            _sportCenterRepository = sportCenterRepository;
+            _outboxService = outboxService;
+            _dbContext = dbContext;
+        }
+
+        public async Task<CancelBookingByOwnerResult> Handle(CancelBookingByOwnerCommand request, CancellationToken cancellationToken)
+        {
+            // Get the booking by ID
+            var booking = await _bookingRepository.GetBookingByIdAsync(BookingId.Of(request.BookingId), cancellationToken);
+
+            if (booking == null)
+            {
+                throw new NotFoundException($"Booking with ID {request.BookingId} not found");
+            }
+
+            // Check if the booking is already cancelled
+            if (booking.Status == BookingStatus.Cancelled)
+            {
+                throw new InvalidOperationException("The booking is already cancelled");
+            }
+
+            // Verify the owner has permission to cancel this booking
+            var bookingDetails = await _bookingRepository.GetBookingDetailsAsync(booking.Id, cancellationToken);
+            if (bookingDetails == null || !bookingDetails.Any())
+            {
+                throw new InvalidOperationException("The booking has no court details");
+            }
+
+            Guid? courtId = bookingDetails.First().CourtId?.Value;
+            if (courtId == null)
+            {
+                throw new InvalidOperationException("The booking has invalid court information");
+            }
+
+            // Check if the requester is the owner of the court
+            bool isAuthorized = false;
+            var court = await _courtRepository.GetCourtByIdAsync(CourtId.Of(courtId.Value), cancellationToken);
+            if (court != null && court.SportCenterId != null)
+            {
+                try
+                {
+                    var isSportCenterOwner = await _sportCenterRepository.IsOwnedByUserAsync(
+                        court.SportCenterId.Value, request.OwnerId, cancellationToken);
+
+                    if (isSportCenterOwner)
+                        isAuthorized = true;
+                }
+                catch (NotFoundException)
+                {
+                    // Fallback check
+                    try
+                    {
+                        var sportCenter = await _sportCenterRepository.GetSportCenterByIdAsync(
+                            court.SportCenterId, cancellationToken);
+
+                        if (sportCenter != null && sportCenter.OwnerId.Value == request.OwnerId)
+                            isAuthorized = true;
+                    }
+                    catch
+                    {
+                        // If still can't find sport center, continue to unauthorized check
+                    }
+                }
+            }
+
+            if (!isAuthorized)
+            {
+                throw new UnauthorizedAccessException("You don't have permission to cancel this booking");
+            }
+
+            // Begin transaction
+            using var transaction = await _dbContext.BeginTransactionAsync(cancellationToken);
+            try
+            {
+                // For owner cancellations, refund 100% of the paid amount
+                decimal refundAmount = booking.TotalPrice - booking.RemainingBalance;
+
+                // Update booking status and cancellation reason
+                booking.Cancel();
+                booking.SetCancellationReason(request.CancellationReason);
+                booking.SetCancellationTime(request.RequestedAt);
+
+                // Save changes to the database
+                await _bookingRepository.UpdateBookingAsync(booking, cancellationToken);
+
+                // Get the sport center owner
+                var sportCenter = await _sportCenterRepository.GetSportCenterByIdAsync(court.SportCenterId, cancellationToken);
+                var sportCenterOwnerId = sportCenter.OwnerId.Value;
+
+                // Create a booking cancelled refund event with 100% refund
+                var bookingCancelledRefundEvent = new BookingCancelledRefundEvent(
+                    booking.Id.Value,
+                    booking.UserId.Value,
+                    sportCenterOwnerId,
+                    refundAmount,
+                    $"[OWNER CANCELLED] {request.CancellationReason}",
+                    request.RequestedAt);
+
+                await _outboxService.SaveMessageAsync(bookingCancelledRefundEvent);
+
+                // Also save notification event for other systems
+                var bookingCancelledNotificationEvent = new BookingCancelledNotificationEvent(
+                    booking.Id.Value,
+                    booking.UserId.Value,
+                    court.SportCenterId.Value,
+                    true, // Always refund when owner cancels
+                    refundAmount,
+                    $"[OWNER CANCELLED] {request.CancellationReason}",
+                    request.RequestedAt);
+
+                await _outboxService.SaveMessageAsync(bookingCancelledNotificationEvent);
+
+                // Commit the transaction
+                await transaction.CommitAsync(cancellationToken);
+
+                // Return result
+                return new CancelBookingByOwnerResult(
+                    booking.Id.Value,
+                    BookingStatus.Cancelled.ToString(),
+                    refundAmount,
+                    "Booking cancelled by owner with 100% refund"
+                );
+            }
+            catch (Exception)
+            {
+                // Rollback the transaction if an error occurred
+                await transaction.RollbackAsync(cancellationToken);
+                throw;
+            }
+        }
+    }
+}

--- a/src/Services/CourtBooking/CourtBooking.Application/CourtManagement/Command/DeleteCourt/DeleteCourtHandler.cs
+++ b/src/Services/CourtBooking/CourtBooking.Application/CourtManagement/Command/DeleteCourt/DeleteCourtHandler.cs
@@ -1,21 +1,25 @@
 ﻿using CourtBooking.Application.Data.Repositories;
 using CourtBooking.Application.Exceptions;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using BuildingBlocks.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using FluentValidation;
+using CourtBooking.Domain.Enums;
 
 namespace CourtBooking.Application.CourtManagement.Command.DeleteCourt
 {
     public class DeleteCourtHandler : ICommandHandler<DeleteCourtCommand, DeleteCourtResult>
     {
         private readonly ICourtRepository _courtRepository;
+        private readonly IBookingRepository _bookingRepository;
 
-        public DeleteCourtHandler(ICourtRepository courtRepository)
+        public DeleteCourtHandler(ICourtRepository courtRepository, IBookingRepository bookingRepository)
         {
             _courtRepository = courtRepository;
+            _bookingRepository = bookingRepository;
         }
 
         public async Task<DeleteCourtResult> Handle(DeleteCourtCommand command, CancellationToken cancellationToken)
@@ -25,6 +29,18 @@ namespace CourtBooking.Application.CourtManagement.Command.DeleteCourt
             if (court == null)
             {
                 throw new CourtNotFoundException(command.CourtId);
+            }
+
+            // Check for active bookings
+            var activeBookings = await _bookingRepository.GetActiveBookingsForCourtAsync(
+                courtId,
+                new[] { BookingStatus.Deposited, BookingStatus.Completed },
+                DateTime.UtcNow,
+                cancellationToken);
+
+            if (activeBookings.Any())
+            {
+                throw new ValidationException("Không thể xóa sân vì có lịch đặt sân còn hoạt động.");
             }
 
             await _courtRepository.DeleteCourtAsync(courtId, cancellationToken);

--- a/src/Services/CourtBooking/CourtBooking.Application/Data/Repositories/IBookingRepository.cs
+++ b/src/Services/CourtBooking/CourtBooking.Application/Data/Repositories/IBookingRepository.cs
@@ -46,5 +46,19 @@ namespace CourtBooking.Application.Data.Repositories
         /// Lấy danh sách booking trong khoảng thời gian cho một sân cụ thể
         /// </summary>
         Task<IEnumerable<Booking>> GetBookingsInDateRangeForCourtAsync(Guid courtId, DateTime startDate, DateTime endDate, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Gets active bookings for a court with specified statuses and booking date after the given date
+        /// </summary>
+        /// <param name="courtId">The ID of the court</param>
+        /// <param name="statuses">The booking statuses to include</param>
+        /// <param name="afterDate">The date after which to check bookings</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>List of active bookings</returns>
+        Task<List<Booking>> GetActiveBookingsForCourtAsync(
+            CourtId courtId,
+            BookingStatus[] statuses,
+            DateTime afterDate,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/Services/CourtBooking/CourtBooking.Infrastructure/Data/Repositories/BookingRepository.cs
+++ b/src/Services/CourtBooking/CourtBooking.Infrastructure/Data/Repositories/BookingRepository.cs
@@ -162,5 +162,21 @@ namespace CourtBooking.Infrastructure.Data.Repositories
                            b.BookingDetails.Any(bd => bd.CourtId == CourtId.Of(courtId)))
                 .ToListAsync(cancellationToken);
         }
+
+        public async Task<List<Booking>> GetActiveBookingsForCourtAsync(
+            CourtId courtId,
+            BookingStatus[] statuses,
+            DateTime afterDate,
+            CancellationToken cancellationToken)
+        {
+            return await _context.Bookings
+                .Include(b => b.BookingDetails)
+                .Where(b => b.BookingDetails.Any(bd => bd.CourtId == courtId) &&
+                            statuses.Contains(b.Status) &&
+                            b.BookingDate >= afterDate &&
+                            b.Status != BookingStatus.PendingPayment &&
+                            b.Status != BookingStatus.Cancelled)
+                .ToListAsync(cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces a new feature for court owners to cancel bookings with a 100% refund, alongside several related enhancements and validations. It also adds safeguards to prevent deletion of courts or sport centers with active bookings. Below is a summary of the most important changes:

### New Feature: Court Owner Booking Cancellation
* Added a new command, `CancelBookingByOwnerCommand`, and its handler to enable court owners to cancel bookings with a 100% refund. Includes validation, database updates, and event publishing to notify other systems. (`src/Services/CourtBooking/CourtBooking.Application/BookingManagement/Command/CancelBookingByOwner/CancelBookingByOwnerCommand.cs`, `src/Services/CourtBooking/CourtBooking.Application/BookingManagement/Command/CancelBookingByOwner/CancelBookingByOwnerCommandHandler.cs`) [[1]](diffhunk://#diff-9688bb29b739c65df4c239ded4381044a962d2305ee908e8873d6e1cada37610R1-R31) [[2]](diffhunk://#diff-629b9efc5ca37290e6230dd66a1133dc83860cc64d5cd119d06d5b637e70ef7aR1-R165)
* Introduced a new API endpoint, `/cancel-by-owner`, for court owners to cancel bookings. Includes request validation, authorization checks, and response handling. (`src/Services/CourtBooking/CourtBooking.API/Endpoints/BookingEndpoints.cs`)

### Enhancements to Booking Management
* Added a method, `GetActiveBookingsForCourtAsync`, to the booking repository to retrieve active bookings for a specific court. This is used to ensure courts and sport centers with active bookings cannot be deleted. (`src/Services/CourtBooking/CourtBooking.Application/Data/Repositories/IBookingRepository.cs`, `src/Services/CourtBooking/CourtBooking.Infrastructure/Data/Repositories/BookingRepository.cs`) [[1]](diffhunk://#diff-93d15ebf8d6c906f5548f8d2dcbe206f5173ae9a73ffa0962816b772e40762a4R49-R62) [[2]](diffhunk://#diff-fde5ec987dd8ff99e319bad72b525e099d10f9d2df9cc108c3f770e10514f70cR165-R180)

### Safeguards for Court and Sport Center Deletion
* Updated the `DeleteCourtHandler` to prevent deletion of courts with active bookings. (`src/Services/CourtBooking/CourtBooking.Application/CourtManagement/Command/DeleteCourt/DeleteCourtHandler.cs`)
* Updated the `DeleteSportCenterHandler` to ensure sport centers with courts that have active bookings cannot be deleted. (`src/Services/CourtBooking/CourtBooking.Application/CourtManagement/Command/DeleteSportCenter/DeleteSportCenterHandler.cs`)

### Minor Changes
* Removed unnecessary validation for completed bookings in the coach booking cancellation logic. (`src/Services/Coach/Coach.API/Features/Bookings/CancelBooking/CancelCoachBookingCommandHandler.cs`)
* Added new request models for booking cancellation by owners. (`src/Services/CourtBooking/CourtBooking.API/Endpoints/BookingEndpoints.cs`)